### PR TITLE
Update installation pre-requisites when using MacPorts on Mac OS X 10.10.

### DIFF
--- a/install_prereqs.sh
+++ b/install_prereqs.sh
@@ -4,7 +4,7 @@ case $1 in
   ("homebrew")
     brew install qt qwt ;;
   ("macports")
-    echo "WARNING: install_prereqs macports not implemented for this module" ;;
+    port install qt4-mac qwt ;;
   ("ubuntu")
     apt-get install python-dev libqt4-dev libqwt-dev ;;
   ("cygwin")


### PR DESCRIPTION
This commit updates the install_prereqs.sh script to install qt4-mac and
qwt using MacPorts-2.3.4, on Mac OS X 10.10.

Signed-off-by: Elvis Dowson elvis.dowson@gmail.com
