### PR TITLE
Support for signal functions with multiple output

### DIFF
--- a/examples/example8.py
+++ b/examples/example8.py
@@ -1,0 +1,14 @@
+'''
+This example shows how to define a custom function that outputs multiple values.
+The function must return two values, the timestamp in microseconds
+and an array of signal values.  The function documentation and the key
+are used to define a label or name for the signal, unless labels are
+explicitly specified.
+'''
+
+def myFunction(msg):
+    '''velocity in mph'''
+    return msg.utime, [v*2.23694 for v in msg.vel]
+
+
+addSignalFunction('POSE_BODY', myFunction, [0, 1, 2])

--- a/examples/example8.py
+++ b/examples/example8.py
@@ -11,4 +11,4 @@ def myFunction(msg):
     return msg.utime, [v*2.23694 for v in msg.vel]
 
 
-addSignalFunction('POSE_BODY', myFunction, [0, 1, 2])
+addSignalFunctions('POSE_BODY', myFunction, [0, 1, 2])

--- a/src/signal_scope/signalScopeSetup.py
+++ b/src/signal_scope/signalScopeSetup.py
@@ -223,7 +223,7 @@ def addSignalFunctions(channel, signalFunction, keys, keyLookup=None, plot=None,
         if keyLookup is not None:
             key = keyLookup[key]
 
-        addSignalFunction(channel, func(key,keyStr), plot=plot, color=colors, label=labels)
+        addSignalFunction(channel, func(key,keyStr), plot=plot, color=color, label=label)
 
 
 

--- a/src/signal_scope/signalScopeSetup.py
+++ b/src/signal_scope/signalScopeSetup.py
@@ -209,6 +209,7 @@ def addSignalFunctions(channel, signalFunction, keys, keyLookup=None, plot=None,
         f = lambda msg: (signalFunction(msg)[0], signalFunction(msg)[1][key])
         if signalFunction.__doc__:
             f.__doc__ = signalFunction.__doc__ + " " + keyStr
+        return f
 
     if colors is None:
         colors = [None] * len(keys)

--- a/src/signal_scope/signalScopeSetup.py
+++ b/src/signal_scope/signalScopeSetup.py
@@ -219,7 +219,7 @@ def addSignalFunctions(channel, signalFunction, keys, keyLookup=None, plot=None,
 
     for key, color, label in zip(keys, colors, labels):
 
-        keyStr = key        
+        keyStr = str(key)        
         if keyLookup is not None:
             key = keyLookup[key]
 

--- a/src/signal_scope/signalScopeSetup.py
+++ b/src/signal_scope/signalScopeSetup.py
@@ -206,7 +206,7 @@ def addSignalFunction(channel, signalFunction, plot=None, color=None, wrap=True,
 def addSignalFunctions(channel, signalFunction, keys, keyLookup=None, plot=None, colors=None, labels=None):
     
     def func(key, keyStr):
-        f = lambda msg: signalFunction(msg)[0], signalFunction(msg)[1][key]
+        f = lambda msg: (signalFunction(msg)[0], signalFunction(msg)[1][key])
         if signalFunction.__doc__:
             f.__doc__ = signalFunction.__doc__ + " " + keyStr
 

--- a/src/signal_scope/signalScopeSetup.py
+++ b/src/signal_scope/signalScopeSetup.py
@@ -203,18 +203,44 @@ def addSignalFunction(channel, signalFunction, plot=None, color=None, wrap=True,
     _mainWindow.addPythonSignal(plot, [channel, _signalFunction, label or signalFunction.__doc__, color])
 
 
+def addSignalFunctions(channel, signalFunction, keys, keyLookup=None, plot=None, colors=None, labels=None):
+    
+    def func(key, keyStr):
+        f = lambda msg: signalFunction(msg)[0], signalFunction(msg)[1][key]
+        if signalFunction.__doc__:
+            f.__doc__ = signalFunction.__doc__ + " " + keyStr
+
+    if colors is None:
+        colors = [None] * len(keys)
+
+    if labels is None:
+        labels = [None] * len(keys)
+
+    for key, color, label in zip(keys, colors, labels):
+
+        keyStr = key        
+        if keyLookup is not None:
+            key = keyLookup[key]
+
+        addSignalFunction(channel, func(key,keyStr), plot=plot, color=colors, label=labels)
+
+
+
 def addSignal(channel, timeLookup, valueLookup, plot=None, color=None, label=None):
 
     signalFunction = createSignalFunction(timeLookup, valueLookup)
     addSignalFunction(channel, signalFunction, plot=plot, color=color, wrap=False, label=label)
 
 
-def addSignals(channel, timeLookup, valueLookup, keys, keyLookup=None, plot=None, colors=None):
+def addSignals(channel, timeLookup, valueLookup, keys, keyLookup=None, plot=None, colors=None, labels=None):
 
     if colors is None:
         colors = [None] * len(keys)
 
-    for key, color in zip(keys, colors):
+    if labels is None:
+        labels = [None] * len(keys)
+
+    for key, color, label in zip(keys, colors, labels):
 
         if keyLookup is not None:
             key = keyLookup[key]

--- a/src/signal_scope/signalScopeSetup.py
+++ b/src/signal_scope/signalScopeSetup.py
@@ -206,7 +206,9 @@ def addSignalFunction(channel, signalFunction, plot=None, color=None, wrap=True,
 def addSignalFunctions(channel, signalFunction, keys, keyLookup=None, plot=None, colors=None, labels=None):
     
     def func(key, keyStr):
-        f = lambda msg: (signalFunction(msg)[0], signalFunction(msg)[1][key])
+        def f (msg):
+            t, x = signalFunction(msg)
+            return t, x[key]
         if signalFunction.__doc__:
             f.__doc__ = signalFunction.__doc__ + " " + keyStr
         return f
@@ -246,4 +248,4 @@ def addSignals(channel, timeLookup, valueLookup, keys, keyLookup=None, plot=None
         if keyLookup is not None:
             key = keyLookup[key]
 
-        addSignal(channel, timeLookup, valueLookup[key], plot=plot, color=color)
+        addSignal(channel, timeLookup, valueLookup[key], plot=plot, color=color, label=label)


### PR DESCRIPTION
This PR adds the `addSignalFunctions` function to  allows users to create functions that return multiple signals. It also includes an example in `example8.py` to instruct users how to use the functionality.

I also took the liberty of adding support for multiple labels in the `addSignals` function.
