### PR TITLE
LCM can be found using lcm CMake configuration file

### DIFF
--- a/cmake/FindLCM.cmake
+++ b/cmake/FindLCM.cmake
@@ -7,6 +7,11 @@
 # <package>_INCLUDE_DIRS
 # <package>_LIBRARIES
 
+find_package(lcm QUIET CONFIG)
+if(lcm_FOUND)
+  set(LCM_LIBRARIES lcm::lcm)
+  return()
+endif()
 
 macro(pkg_config_find_module varname pkgname header library pathsuffix)
 


### PR DESCRIPTION
This allows targets to have transitive dependencies. such as lcm
depending on glib-2.0 and pthread