### PR TITLE
Support Qt4 and Qt5

### DIFF
--- a/install_prereqs.sh
+++ b/install_prereqs.sh
@@ -7,6 +7,8 @@ case $1 in
     port install qt4-mac qwt ;;
   ("ubuntu")
     apt-get install python-dev libqt4-dev libqwt-dev ;;
+  ("ubuntu-xenial")
+    apt-get install python-dev qtscript5-dev libqwt-qt5-dev ;;
   ("cygwin")
     echo "WARNING: install_prereqs cygwin not implemented for this module" ;;
   (*)
@@ -15,6 +17,7 @@ case $1 in
     echo "  homebrew"
     echo "  macports"
     echo "  ubuntu"
+    echo "  ubuntu-xenial"
     echo "  cygwin"
     exit 1 ;;
 esac

--- a/src/signal_scope/CMakeLists.txt
+++ b/src/signal_scope/CMakeLists.txt
@@ -1,9 +1,23 @@
-find_package(Qt4 REQUIRED QtCore QtGui QtScript)
-include(${QT_USE_FILE})
-
+if("${USED_QTVERSION}" STREQUAL "5")
+  find_package(Qt5 REQUIRED Core Gui Script Widgets)
+  set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Script Qt5::Widgets)
+  # Compatibility macros
+  macro(qt4_wrap_cpp)
+    qt5_wrap_cpp(${ARGN})
+  endmacro()
+  macro(qt4_wrap_ui)
+    qt5_wrap_ui(${ARGN})
+  endmacro()
+  macro(qt4_add_resources)
+    qt5_add_resources(${ARGN})
+  endmacro()
+  find_library(QWT_LIBRARY qwt-qt5)
+else()
+  find_library(QWT_LIBRARY qwt)
+  find_package(Qt4 REQUIRED QtCore QtGui QtScript)
+  include(${QT_USE_FILE})
+endif()
 find_package(LCM REQUIRED)
-
-
 
 set(deps)
 
@@ -21,8 +35,6 @@ endif()
 
 
 find_path(QWT_INCLUDE_DIR qwt/qwt.h HINTS /usr/local/lib)
-find_library(QWT_LIBRARY qwt)
-
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${QWT_INCLUDE_DIR})
 include_directories(${LCM_INCLUDE_DIRS})
@@ -59,7 +71,6 @@ if(USE_PYTHON)
     )
   set(python_srcs)
 endif()
-
 
 qt4_wrap_cpp(moc_srcs
   mainwindow.h

--- a/src/signal_scope/pythonchannelsubscriber.h
+++ b/src/signal_scope/pythonchannelsubscriber.h
@@ -32,7 +32,11 @@ public:
       printf("error: subscribe() called without first calling unsubscribe.\n");
       return;
     }
+#if QT_VERSION >= 0x050000
+    mSubscription = lcmHandle->subscribe(this->channel().toLatin1().data(), &PythonChannelSubscriber::handleMessageOnChannel, this);
+#else
     mSubscription = lcmHandle->subscribe(this->channel().toAscii().data(), &PythonChannelSubscriber::handleMessageOnChannel, this);
+#endif
   }
 
 

--- a/src/signal_scope/signalhandler.cpp
+++ b/src/signal_scope/signalhandler.cpp
@@ -41,7 +41,11 @@ void SignalHandler::subscribe(lcm::LCM* lcmInstance)
     printf("error: SignalHandler::subscribe() called without first calling unsubscribe.\n");
     return;
   }
+#if QT_VERSION >= 0x050000
+  mSubscription = lcmInstance->subscribe(this->channel().toLatin1().data(), &SignalHandler::handleMessage, this);
+#else
   mSubscription = lcmInstance->subscribe(this->channel().toAscii().data(), &SignalHandler::handleMessage, this);
+#endif
 }
 
 SignalHandlerFactory& SignalHandlerFactory::instance()


### PR DESCRIPTION
Qt version is given by CMake variable USED_QTVERSION. If Qt version is 5,
use Qt5, otherwise use Qt4 (backward compatibility).